### PR TITLE
fix: read default url from QATARINA_HOST env var

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/build/
+/dist/
+/data/
+/logs/
+qatarina-cli
+*.exe

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,18 @@
+version: 3
+tasks:  
+  build:
+    # lint the go code first
+    - golangci-lint
+    - go build -o build/qatarina-cli
+
+  build-pr:
+    - gh pr checkout {{.CLI_ARGS}}
+    - go vet 
+    - task build
+  
+  install-local:
+    deps: [ build ]
+    cmds:
+      - cp ./build/qatarina-cli $HOME/bin/
+
+    

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-
+	"os"
 	"github.com/wakisa/qatarina-cli/internal/auth"
 )
 
@@ -25,8 +25,14 @@ func NewClient(url string) *Client {
 
 }
 
+// Default creates a new client that connects to default URL 
+// or host specified in the environment variable `QATARINA_HOST`
 func Default() *Client {
-	return NewClient("http://localhost:4597/")
+	url := os.Getenv("QATARINA_HOST")
+	if url == "" {
+		url = "http://localhost:4597"
+	}
+	return NewClient(url)
 }
 
 func (c *Client) Post(path string, body []byte) (*http.Response, error) {


### PR DESCRIPTION
Default client's url is now read first from QATARINA_HOST env var. 
Added .gitignore and Taskfile for the project